### PR TITLE
[REFACTOR] OAuth 로그인 관련 리팩토링

### DIFF
--- a/src/main/java/com/example/spot/auth/application/refactor/OAuthService.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/OAuthService.java
@@ -1,6 +1,6 @@
 package com.example.spot.auth.application.refactor;
 
-import com.example.spot.auth.application.refactor.member.OAuthMemberProcessor;
+import com.example.spot.auth.application.refactor.impl.OAuthMemberProcessor;
 import com.example.spot.auth.application.refactor.strategy.OAuthStrategy;
 import com.example.spot.auth.application.refactor.strategy.OAuthStrategyFactory;
 import com.example.spot.member.domain.enums.LoginType;

--- a/src/main/java/com/example/spot/auth/application/refactor/OAuthService.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/OAuthService.java
@@ -21,6 +21,6 @@ public class OAuthService {
 
     public SocialLoginSignInDTO loginOrSignUp(LoginType type, String code) {
         OAuthStrategy strategy = strategyFactory.getStrategy(type);
-        return memberProcessor.processOAuthMember(type, strategy.toMember(code));
+        return memberProcessor.processOAuthMember(strategy.getOAuthProfile(code));
     }
 }

--- a/src/main/java/com/example/spot/auth/application/refactor/OAuthService.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/OAuthService.java
@@ -1,6 +1,6 @@
 package com.example.spot.auth.application.refactor;
 
-import com.example.spot.auth.application.refactor.impl.OAuthMemberProcessor;
+import com.example.spot.auth.application.refactor.member.OAuthMemberProcessor;
 import com.example.spot.auth.application.refactor.strategy.OAuthStrategy;
 import com.example.spot.auth.application.refactor.strategy.OAuthStrategyFactory;
 import com.example.spot.member.domain.enums.LoginType;

--- a/src/main/java/com/example/spot/auth/application/refactor/TokenProvider.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/TokenProvider.java
@@ -1,0 +1,23 @@
+package com.example.spot.auth.application.refactor;
+
+import com.example.spot.auth.presentation.dto.token.TokenResponseDTO.TokenDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface TokenProvider {
+
+    TokenDTO createToken(Long memberId);
+
+    TokenDTO reissueToken(String refreshToken);
+
+    boolean isTokenExpired(String token);
+
+    boolean validateToken(String token);
+
+    Authentication getAuthentication(String token, UserDetails userDetails);
+
+    String resolveToken(HttpServletRequest request);
+
+    Long getMemberIdByToken(String token);
+}

--- a/src/main/java/com/example/spot/auth/application/refactor/TokenReissueService.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/TokenReissueService.java
@@ -2,7 +2,7 @@ package com.example.spot.auth.application.refactor;
 
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO;
 
-public interface TokenService {
+public interface TokenReissueService {
 
 	// 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급
 	TokenResponseDTO.TokenDTO reissueToken(String refreshToken);

--- a/src/main/java/com/example/spot/auth/application/refactor/dto/OAuthProfile.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/dto/OAuthProfile.java
@@ -1,0 +1,15 @@
+package com.example.spot.auth.application.refactor.dto;
+
+import com.example.spot.member.domain.enums.LoginType;
+
+public record OAuthProfile(
+        LoginType loginType,
+        String email,
+        String nickname,
+        String profileImageUrl
+) {
+
+    public static OAuthProfile of(LoginType loginType, String email, String nickname, String profileImageUrl) {
+        return new OAuthProfile(loginType, email, nickname, profileImageUrl);
+    }
+}

--- a/src/main/java/com/example/spot/auth/application/refactor/dto/SocialAccountResult.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/dto/SocialAccountResult.java
@@ -1,0 +1,16 @@
+package com.example.spot.auth.application.refactor.dto;
+
+import com.example.spot.member.domain.Member;
+import java.util.Optional;
+
+public record SocialAccountResult(
+        Optional<Member> member
+) {
+    public static SocialAccountResult empty() {
+        return new SocialAccountResult(Optional.empty());
+    }
+
+    public static SocialAccountResult of(Member member) {
+        return new SocialAccountResult(Optional.of(member));
+    }
+}

--- a/src/main/java/com/example/spot/auth/application/refactor/impl/JwtTokenReissueService.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/impl/JwtTokenReissueService.java
@@ -1,12 +1,12 @@
 package com.example.spot.auth.application.refactor.impl;
 
-import com.example.spot.auth.application.refactor.TokenService;
+import com.example.spot.auth.application.refactor.TokenProvider;
+import com.example.spot.auth.application.refactor.TokenReissueService;
 import com.example.spot.auth.domain.RefreshToken;
 import com.example.spot.auth.infrastructure.jpa.RefreshTokenRepository;
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO;
 import com.example.spot.common.api.code.status.ErrorStatus;
 import com.example.spot.common.api.exception.GeneralException;
-import com.example.spot.common.security.utils.JwtTokenProvider;
 import com.example.spot.member.domain.Member;
 import com.example.spot.member.infrastructure.jpa.MemberRepository;
 import java.util.Objects;
@@ -17,10 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class JwtTokenService implements TokenService {
+public class JwtTokenReissueService implements TokenReissueService {
 
     private final MemberRepository memberRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
     /**

--- a/src/main/java/com/example/spot/auth/application/refactor/impl/OAuthMemberProcessor.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/impl/OAuthMemberProcessor.java
@@ -1,5 +1,6 @@
 package com.example.spot.auth.application.refactor.impl;
 
+import com.example.spot.auth.application.refactor.dto.OAuthProfile;
 import com.example.spot.auth.domain.RefreshToken;
 import com.example.spot.auth.infrastructure.jpa.RefreshTokenRepository;
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO;
@@ -7,7 +8,6 @@ import com.example.spot.common.api.code.status.ErrorStatus;
 import com.example.spot.common.api.exception.GeneralException;
 import com.example.spot.common.security.utils.JwtTokenProvider;
 import com.example.spot.member.domain.Member;
-import com.example.spot.member.domain.enums.LoginType;
 import com.example.spot.member.infrastructure.jpa.MemberRepository;
 import com.example.spot.member.infrastructure.jpa.PreferredRegionRepository;
 import com.example.spot.member.infrastructure.jpa.PreferredThemeRepository;
@@ -33,11 +33,10 @@ public class OAuthMemberProcessor {
     private EntityManager entityManager;
 
     @Transactional
-    public MemberResponseDTO.SocialLoginSignInDTO processOAuthMember(LoginType loginType,
-                                                                     Member providerMember) {
+    public MemberResponseDTO.SocialLoginSignInDTO processOAuthMember(OAuthProfile oAuthProfile) {
         // 다른 로그인 타입으로 가입된 경우
-        if (memberRepository.existsByEmailAndLoginTypeNot(providerMember.getEmail(), loginType)) {
-            Member existing = memberRepository.findByEmail(providerMember.getEmail())
+        if (memberRepository.existsByEmailAndLoginTypeNot(oAuthProfile.email(), oAuthProfile.loginType())) {
+            Member existing = memberRepository.findByEmail(oAuthProfile.email())
                     .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
             if (existing.getInactive() != null) {
                 refreshTokenRepository.deleteByMemberId(existing.getId());
@@ -49,7 +48,7 @@ public class OAuthMemberProcessor {
         }
 
         boolean isSpotMember = false;
-        Member member = memberRepository.findByEmail(providerMember.getEmail()).orElse(null);
+        Member member = memberRepository.findByEmail(oAuthProfile.email()).orElse(null);
 
         if (member != null && member.getInactive() != null) {
             refreshTokenRepository.deleteByMemberId(member.getId());
@@ -59,7 +58,10 @@ public class OAuthMemberProcessor {
         }
 
         if (member == null) {
-            member = memberRepository.save(providerMember);
+            Member memberByOAuth = Member.toMemberByOAuth(oAuthProfile.loginType(), oAuthProfile.nickname(),
+                    oAuthProfile.email(),
+                    oAuthProfile.profileImageUrl());
+            member = memberRepository.save(memberByOAuth);
         }
 
         isSpotMember = checkIsSpotMember(member);

--- a/src/main/java/com/example/spot/auth/application/refactor/impl/OAuthMemberProcessor.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/impl/OAuthMemberProcessor.java
@@ -1,8 +1,12 @@
-package com.example.spot.auth.application.refactor.member;
+package com.example.spot.auth.application.refactor.impl;
 
 import com.example.spot.auth.application.refactor.TokenProvider;
 import com.example.spot.auth.application.refactor.dto.OAuthProfile;
 import com.example.spot.auth.application.refactor.dto.SocialAccountResult;
+import com.example.spot.auth.application.refactor.member.OAuthMemberConflictProcessor;
+import com.example.spot.auth.application.refactor.member.OAuthMemberCreator;
+import com.example.spot.auth.application.refactor.member.ProfileCompletenessChecker;
+import com.example.spot.auth.application.refactor.member.RefreshTokenStore;
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO.TokenDTO;
 import com.example.spot.member.domain.Member;
 import com.example.spot.member.presentation.dto.MemberResponseDTO;
@@ -17,7 +21,7 @@ public class OAuthMemberProcessor {
     private final OAuthMemberCreator oAuthMemberCreator;
     private final OAuthMemberConflictProcessor oAuthMemberConflictProcessor;
     private final ProfileCompletenessChecker profileCompletenessChecker;
-    private final TokenProvider tokenProvider; // TODO 인터페이스 분리
+    private final TokenProvider tokenProvider;
     private final RefreshTokenStore refreshTokenStore;
 
     @Transactional

--- a/src/main/java/com/example/spot/auth/application/refactor/impl/OAuthMemberProcessor.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/impl/OAuthMemberProcessor.java
@@ -1,20 +1,15 @@
 package com.example.spot.auth.application.refactor.impl;
 
 import com.example.spot.auth.application.refactor.dto.OAuthProfile;
-import com.example.spot.auth.domain.RefreshToken;
-import com.example.spot.auth.infrastructure.jpa.RefreshTokenRepository;
-import com.example.spot.auth.presentation.dto.token.TokenResponseDTO;
-import com.example.spot.common.api.code.status.ErrorStatus;
-import com.example.spot.common.api.exception.GeneralException;
+import com.example.spot.auth.application.refactor.dto.SocialAccountResult;
+import com.example.spot.auth.application.refactor.member.OAuthMemberConflictProcessor;
+import com.example.spot.auth.application.refactor.member.OAuthMemberCreator;
+import com.example.spot.auth.application.refactor.member.ProfileCompletenessChecker;
+import com.example.spot.auth.application.refactor.member.RefreshTokenStore;
+import com.example.spot.auth.presentation.dto.token.TokenResponseDTO.TokenDTO;
 import com.example.spot.common.security.utils.JwtTokenProvider;
 import com.example.spot.member.domain.Member;
-import com.example.spot.member.infrastructure.jpa.MemberRepository;
-import com.example.spot.member.infrastructure.jpa.PreferredRegionRepository;
-import com.example.spot.member.infrastructure.jpa.PreferredThemeRepository;
-import com.example.spot.member.infrastructure.jpa.StudyJoinReasonRepository;
 import com.example.spot.member.presentation.dto.MemberResponseDTO;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,74 +18,29 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OAuthMemberProcessor {
 
-    private final MemberRepository memberRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final JwtTokenProvider tokenProvider;
-    private final PreferredThemeRepository preferredThemeRepository;
-    private final PreferredRegionRepository preferredRegionRepository;
-    private final StudyJoinReasonRepository studyJoinReasonRepository;
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final OAuthMemberCreator oAuthMemberCreator;
+    private final OAuthMemberConflictProcessor oAuthMemberConflictProcessor;
+    private final ProfileCompletenessChecker profileCompletenessChecker;
+    private final JwtTokenProvider tokenService; // TODO 인터페이스 분리
+    private final RefreshTokenStore refreshTokenStore;
 
     @Transactional
     public MemberResponseDTO.SocialLoginSignInDTO processOAuthMember(OAuthProfile oAuthProfile) {
-        // 다른 로그인 타입으로 가입된 경우
-        if (memberRepository.existsByEmailAndLoginTypeNot(oAuthProfile.email(), oAuthProfile.loginType())) {
-            Member existing = memberRepository.findByEmail(oAuthProfile.email())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-            if (existing.getInactive() != null) {
-                refreshTokenRepository.deleteByMemberId(existing.getId());
-                memberRepository.deleteById(existing.getId());
-                entityManager.flush();
-            } else {
-                throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
-            }
-        }
+        SocialAccountResult socialAccountResult = oAuthMemberConflictProcessor.resolveConflict(oAuthProfile);
+        Member member = socialAccountResult.member().orElseGet(() -> oAuthMemberCreator.createFrom(oAuthProfile));
 
-        boolean isSpotMember = false;
-        Member member = memberRepository.findByEmail(oAuthProfile.email()).orElse(null);
+        boolean isSpotMember = profileCompletenessChecker.isComplete(member.getId());
 
-        if (member != null && member.getInactive() != null) {
-            refreshTokenRepository.deleteByMemberId(member.getId());
-            memberRepository.deleteById(member.getId());
-            entityManager.flush();
-            member = null;
-        }
+        TokenDTO token = tokenService.createToken(member.getId());
+        refreshTokenStore.replace(member.getId(), token.getRefreshToken());
 
-        if (member == null) {
-            Member memberByOAuth = Member.toMemberByOAuth(oAuthProfile.loginType(), oAuthProfile.nickname(),
-                    oAuthProfile.email(),
-                    oAuthProfile.profileImageUrl());
-            member = memberRepository.save(memberByOAuth);
-        }
-
-        isSpotMember = checkIsSpotMember(member);
-
-        TokenResponseDTO.TokenDTO token = tokenProvider.createToken(member.getId());
-        saveRefreshToken(member, token);
-
-        return MemberResponseDTO.SocialLoginSignInDTO.toDTO(isSpotMember,
+        return MemberResponseDTO.SocialLoginSignInDTO.toDTO(
+                isSpotMember,
                 MemberResponseDTO.MemberSignInDTO.builder()
                         .tokens(token)
                         .memberId(member.getId())
                         .loginType(member.getLoginType())
                         .email(member.getEmail())
                         .build());
-    }
-
-    private void saveRefreshToken(Member member, TokenResponseDTO.TokenDTO token) {
-        refreshTokenRepository.deleteAllByMemberId(member.getId());
-        RefreshToken refreshToken = RefreshToken.builder()
-                .memberId(member.getId())
-                .token(token.getRefreshToken())
-                .build();
-        refreshTokenRepository.save(refreshToken);
-    }
-
-    private boolean checkIsSpotMember(Member member) {
-        Long id = member.getId();
-        return preferredThemeRepository.existsByMemberId(id) &&
-                preferredRegionRepository.existsByMemberId(id) &&
-                studyJoinReasonRepository.existsByMemberId(id);
     }
 }

--- a/src/main/java/com/example/spot/auth/application/refactor/member/OAuthMemberConflictProcessor.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/member/OAuthMemberConflictProcessor.java
@@ -1,0 +1,51 @@
+package com.example.spot.auth.application.refactor.member;
+
+import com.example.spot.auth.application.refactor.dto.OAuthProfile;
+import com.example.spot.auth.application.refactor.dto.SocialAccountResult;
+import com.example.spot.auth.infrastructure.jpa.RefreshTokenRepository;
+import com.example.spot.common.api.code.status.ErrorStatus;
+import com.example.spot.common.api.exception.GeneralException;
+import com.example.spot.member.domain.Member;
+import com.example.spot.member.infrastructure.jpa.MemberRepository;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthMemberConflictProcessor {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final EntityManager em;
+
+    public SocialAccountResult resolveConflict(OAuthProfile p) {
+        Optional<Member> opt = memberRepository.findByEmail(p.email());
+        if (opt.isEmpty()) {
+            return SocialAccountResult.empty();
+        }
+
+        Member existing = opt.get();
+        // 다른 타입으로 가입된 경우
+        if (existing.getLoginType() != p.loginType()) {
+            if (existing.getInactive() != null) {
+                refreshTokenRepository.deleteByMemberId(existing.getId());
+                memberRepository.deleteById(existing.getId());
+                em.flush();
+
+                return SocialAccountResult.empty();
+            }
+            throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
+        }
+
+        // 같은 타입인데 탈퇴 상태면 정리
+        if (existing.getInactive() != null) {
+            refreshTokenRepository.deleteByMemberId(existing.getId());
+            memberRepository.deleteById(existing.getId());
+            em.flush();
+            return SocialAccountResult.empty();
+        }
+        return SocialAccountResult.of(existing);
+    }
+}

--- a/src/main/java/com/example/spot/auth/application/refactor/member/OAuthMemberCreator.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/member/OAuthMemberCreator.java
@@ -1,0 +1,20 @@
+package com.example.spot.auth.application.refactor.member;
+
+import com.example.spot.auth.application.refactor.dto.OAuthProfile;
+import com.example.spot.member.domain.Member;
+import com.example.spot.member.infrastructure.jpa.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthMemberCreator {
+
+    private final MemberRepository memberRepository;
+
+    public Member createFrom(OAuthProfile oAuthProfile) {
+        Member member = Member.toMemberByOAuth(oAuthProfile.loginType(), oAuthProfile.nickname(), oAuthProfile.email(),
+                oAuthProfile.profileImageUrl());
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/example/spot/auth/application/refactor/member/OAuthMemberProcessor.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/member/OAuthMemberProcessor.java
@@ -1,13 +1,9 @@
-package com.example.spot.auth.application.refactor.impl;
+package com.example.spot.auth.application.refactor.member;
 
+import com.example.spot.auth.application.refactor.TokenProvider;
 import com.example.spot.auth.application.refactor.dto.OAuthProfile;
 import com.example.spot.auth.application.refactor.dto.SocialAccountResult;
-import com.example.spot.auth.application.refactor.member.OAuthMemberConflictProcessor;
-import com.example.spot.auth.application.refactor.member.OAuthMemberCreator;
-import com.example.spot.auth.application.refactor.member.ProfileCompletenessChecker;
-import com.example.spot.auth.application.refactor.member.RefreshTokenStore;
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO.TokenDTO;
-import com.example.spot.common.security.utils.JwtTokenProvider;
 import com.example.spot.member.domain.Member;
 import com.example.spot.member.presentation.dto.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +17,7 @@ public class OAuthMemberProcessor {
     private final OAuthMemberCreator oAuthMemberCreator;
     private final OAuthMemberConflictProcessor oAuthMemberConflictProcessor;
     private final ProfileCompletenessChecker profileCompletenessChecker;
-    private final JwtTokenProvider tokenService; // TODO 인터페이스 분리
+    private final TokenProvider tokenProvider; // TODO 인터페이스 분리
     private final RefreshTokenStore refreshTokenStore;
 
     @Transactional
@@ -31,7 +27,7 @@ public class OAuthMemberProcessor {
 
         boolean isSpotMember = profileCompletenessChecker.isComplete(member.getId());
 
-        TokenDTO token = tokenService.createToken(member.getId());
+        TokenDTO token = tokenProvider.createToken(member.getId());
         refreshTokenStore.replace(member.getId(), token.getRefreshToken());
 
         return MemberResponseDTO.SocialLoginSignInDTO.toDTO(

--- a/src/main/java/com/example/spot/auth/application/refactor/member/ProfileCompletenessChecker.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/member/ProfileCompletenessChecker.java
@@ -1,0 +1,22 @@
+package com.example.spot.auth.application.refactor.member;
+
+import com.example.spot.member.infrastructure.jpa.PreferredRegionRepository;
+import com.example.spot.member.infrastructure.jpa.PreferredThemeRepository;
+import com.example.spot.member.infrastructure.jpa.StudyJoinReasonRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileCompletenessChecker {
+
+    private final PreferredThemeRepository themeRepository;
+    private final PreferredRegionRepository regionRepository;
+    private final StudyJoinReasonRepository reasonRepository;
+
+    public boolean isComplete(Long memberId) {
+        return themeRepository.existsByMemberId(memberId)
+                && regionRepository.existsByMemberId(memberId)
+                && reasonRepository.existsByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/example/spot/auth/application/refactor/member/RefreshTokenStore.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/member/RefreshTokenStore.java
@@ -1,0 +1,21 @@
+package com.example.spot.auth.application.refactor.member;
+
+import com.example.spot.auth.domain.RefreshToken;
+import com.example.spot.auth.infrastructure.jpa.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenStore {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void replace(Long memberId, String refresh) {
+        refreshTokenRepository.deleteAllByMemberId(memberId);
+        refreshTokenRepository.save(RefreshToken.builder()
+                .memberId(memberId).
+                token(refresh)
+                .build());
+    }
+}

--- a/src/main/java/com/example/spot/auth/application/refactor/strategy/OAuthStrategy.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/strategy/OAuthStrategy.java
@@ -1,13 +1,13 @@
 package com.example.spot.auth.application.refactor.strategy;
 
-import com.example.spot.member.domain.Member;
+import com.example.spot.auth.application.refactor.dto.OAuthProfile;
 import com.example.spot.member.domain.enums.LoginType;
 
 public interface OAuthStrategy {
-    
+
     LoginType getType();
 
     String getOauthRedirectURL();
 
-    Member toMember(String code); // 전략별 구현에서 Member 객체 생성
+    OAuthProfile getOAuthProfile(String code); // 전략별 구현에서 Member 객체 생성
 }

--- a/src/main/java/com/example/spot/auth/application/refactor/strategy/OAuthStrategyFactory.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/strategy/OAuthStrategyFactory.java
@@ -3,20 +3,40 @@ package com.example.spot.auth.application.refactor.strategy;
 import com.example.spot.auth.exception.UnsupportedSocialLoginTypeException;
 import com.example.spot.common.api.code.status.ErrorStatus;
 import com.example.spot.member.domain.enums.LoginType;
+import jakarta.annotation.PostConstruct;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class OAuthStrategyFactory {
 
     private final Map<LoginType, OAuthStrategy> strategyMap;
 
+    @PostConstruct
+    void logRegistered() {
+        log.info("Registered OAuth strategies: {}", strategyMap.keySet());
+    }
+
     public OAuthStrategyFactory(List<OAuthStrategy> strategies) {
-        this.strategyMap = strategies.stream()
-                .collect(Collectors.toMap(OAuthStrategy::getType, s -> s));
+        this.strategyMap = Collections.unmodifiableMap(
+                strategies.stream().collect(
+                        Collectors.toMap(
+                                OAuthStrategy::getType,
+                                s -> s,
+                                (a, b) -> {
+                                    throw new IllegalStateException("중복된 OAuth Strategy가 주입되었습니다. :" + a.getType());
+                                },
+                                () -> new EnumMap<>(LoginType.class)
+                        )
+                )
+        );
     }
 
     public OAuthStrategy getStrategy(LoginType type) {

--- a/src/main/java/com/example/spot/auth/application/refactor/strategy/provider/GoogleOAuthStrategy.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/strategy/provider/GoogleOAuthStrategy.java
@@ -1,10 +1,10 @@
 package com.example.spot.auth.application.refactor.strategy.provider;
 
+import com.example.spot.auth.application.refactor.dto.OAuthProfile;
 import com.example.spot.auth.application.refactor.strategy.OAuthStrategy;
 import com.example.spot.auth.infrastructure.oauth.GoogleOauth;
 import com.example.spot.auth.presentation.dto.oauth.google.GoogleOAuthToken;
 import com.example.spot.auth.presentation.dto.oauth.google.GoogleUser;
-import com.example.spot.member.domain.Member;
 import com.example.spot.member.domain.enums.LoginType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -26,9 +26,9 @@ public class GoogleOAuthStrategy implements OAuthStrategy {
     }
 
     @Override
-    public Member toMember(String code) {
+    public OAuthProfile getOAuthProfile(String code) {
         GoogleOAuthToken token = googleOauth.requestAccessToken(code);
         GoogleUser user = googleOauth.requestUserInfo(token);
-        return Member.toMemberByOAuth(getType(), user.name(), user.email(), user.picture());
+        return OAuthProfile.of(getType(), user.name(), user.email(), user.picture());
     }
 }

--- a/src/main/java/com/example/spot/auth/application/refactor/strategy/provider/KakaoOAuthStrategy.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/strategy/provider/KakaoOAuthStrategy.java
@@ -1,10 +1,10 @@
 package com.example.spot.auth.application.refactor.strategy.provider;
 
+import com.example.spot.auth.application.refactor.dto.OAuthProfile;
 import com.example.spot.auth.application.refactor.strategy.OAuthStrategy;
 import com.example.spot.auth.infrastructure.oauth.KaKaoOauth;
 import com.example.spot.auth.presentation.dto.oauth.kakao.KaKaoOAuthTokenDTO;
 import com.example.spot.auth.presentation.dto.oauth.kakao.KaKaoUser;
-import com.example.spot.member.domain.Member;
 import com.example.spot.member.domain.enums.LoginType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -26,10 +26,10 @@ public class KakaoOAuthStrategy implements OAuthStrategy {
     }
 
     @Override
-    public Member toMember(String code) {
+    public OAuthProfile getOAuthProfile(String code) {
         KaKaoOAuthTokenDTO token = kaKaoOauth.requestAccessToken(code);
         KaKaoUser user = kaKaoOauth.requestUserInfo(token);
-        return Member.toMemberByOAuth(getType(), user.properties().nickname(), user.properties().nickname(),
+        return OAuthProfile.of(getType(), user.kakao_account().email(), user.properties().nickname(),
                 user.properties().profile_image());
     }
 }

--- a/src/main/java/com/example/spot/auth/application/refactor/strategy/provider/NaverOAuthStrategy.java
+++ b/src/main/java/com/example/spot/auth/application/refactor/strategy/provider/NaverOAuthStrategy.java
@@ -1,10 +1,10 @@
 package com.example.spot.auth.application.refactor.strategy.provider;
 
+import com.example.spot.auth.application.refactor.dto.OAuthProfile;
 import com.example.spot.auth.application.refactor.strategy.OAuthStrategy;
 import com.example.spot.auth.infrastructure.oauth.NaverOauth;
 import com.example.spot.auth.presentation.dto.oauth.naver.NaverOAuthTokenDTO;
 import com.example.spot.auth.presentation.dto.oauth.naver.NaverUser;
-import com.example.spot.member.domain.Member;
 import com.example.spot.member.domain.enums.LoginType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -26,11 +26,11 @@ public class NaverOAuthStrategy implements OAuthStrategy {
     }
 
     @Override
-    public Member toMember(String code) {
+    public OAuthProfile getOAuthProfile(String code) {
         NaverOAuthTokenDTO token = naverOauth.requestAccessToken(code);
         NaverUser user = naverOauth.requestUserInfo(token);
-        return Member.toMemberByOAuth(
-                getType(), user.response().name(), user.response().email(),
+        return OAuthProfile.of(
+                getType(), user.response().email(), user.response().name(),
                 user.response().thumbnail_image());
     }
 }

--- a/src/main/java/com/example/spot/auth/presentation/controller/refactor/TokenController.java
+++ b/src/main/java/com/example/spot/auth/presentation/controller/refactor/TokenController.java
@@ -1,6 +1,6 @@
 package com.example.spot.auth.presentation.controller.refactor;
 
-import com.example.spot.auth.application.refactor.TokenService;
+import com.example.spot.auth.application.refactor.TokenReissueService;
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO;
 import com.example.spot.common.api.ApiResponse;
 import com.example.spot.common.api.code.status.SuccessStatus;
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TokenController {
 
-    private final TokenService tokenService;
+    private final TokenReissueService tokenReissueService;
 
     /* ----------------------------- JWT 토큰 관리 API ------------------------------------- */
 
@@ -35,7 +35,7 @@ public class TokenController {
     @PostMapping("/reissue")
     public ApiResponse<TokenResponseDTO.TokenDTO> reissueToken(HttpServletRequest request,
                                                                @RequestHeader("refreshToken") String refreshToken) {
-        return ApiResponse.onSuccess(SuccessStatus._CREATED, tokenService.reissueToken(refreshToken));
+        return ApiResponse.onSuccess(SuccessStatus._CREATED, tokenReissueService.reissueToken(refreshToken));
     }
 
 }

--- a/src/main/java/com/example/spot/common/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/common/security/utils/JwtTokenProvider.java
@@ -1,13 +1,22 @@
 package com.example.spot.common.security.utils;
 
-import com.example.spot.common.api.code.status.ErrorStatus;
-import com.example.spot.common.api.exception.GeneralException;
+import com.example.spot.auth.application.refactor.TokenProvider;
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO;
 import com.example.spot.auth.presentation.dto.token.TokenResponseDTO.TokenDTO;
-import io.jsonwebtoken.*;
+import com.example.spot.common.api.code.status.ErrorStatus;
+import com.example.spot.common.api.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,14 +25,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Date;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class JwtTokenProvider {
+public class JwtTokenProvider implements TokenProvider {
 
     @Value("${token.access_secret}")
     private String JWT_SECRET_KEY;
@@ -41,10 +46,11 @@ public class JwtTokenProvider {
 
     /**
      * 토큰을 생성합니다.
+     *
      * @param memberId 회원 ID
      * @return 생성된 토큰
      */
-    // 액세스 및 리프레시 토큰 생성
+    @Override
     public TokenDTO createToken(Long memberId) {
         // 현재 시간
         Date now = new Date();
@@ -53,18 +59,74 @@ public class JwtTokenProvider {
 
         // 토큰 DTO 반환
         return TokenDTO.builder()
-            .accessToken(accessToken)
-            .refreshToken(refreshToken)
-            .accessTokenExpiresIn(ACCESS_TOKEN_EXPIRATION_TIME)
-            .build();
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpiresIn(ACCESS_TOKEN_EXPIRATION_TIME)
+                .build();
     }
 
-    //
+    /**
+     * 리프레시 토큰을 이용하여 토큰을 재발급합니다.
+     *
+     * @param refreshToken 리프레시 토큰
+     * @return 새로 발급된 토큰
+     */
+    @Override
+    public TokenDTO reissueToken(String refreshToken) {
+        Long memberId = getMemberIdByToken(refreshToken);
+        return createToken(memberId);
+    }
+
+    @Override
+    public boolean isTokenExpired(String token) {
+        return validateToken(token, true) == ErrorStatus._EXPIRED_JWT;
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        return validateToken(token, false) == null;
+    }
+
+    /**
+     * 토큰을 이용하여 사용자 인증을 수행합니다.
+     *
+     * @param token       토큰
+     * @param userDetails 사용자 정보
+     * @return 사용자 인증 정보
+     */
+    @Override
+    public Authentication getAuthentication(String token, UserDetails userDetails) {
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    /**
+     * 토큰을 해석하여 회원 ID를 반환합니다.
+     *
+     * @param request HTTP 요청
+     * @return 회원 ID
+     */
+    @Override
+    public String resolveToken(HttpServletRequest request) {
+        return resolveHeaderToken(request, "Authorization", "Bearer ");
+    }
+
+    /**
+     * 토큰을 이용하여 회원 ID를 반환합니다.
+     *
+     * @param token 토큰
+     * @return 회원 ID
+     */
+    @Override
+    public Long getMemberIdByToken(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("memberId", Long.class);
+    }
 
     /**
      * 전화번호 인증을 위한 임시 토큰을 생성합니다
+     *
      * @param email 이메일
-     * @return  생성된 임시 토큰
+     * @return 생성된 임시 토큰
      */
     public TokenResponseDTO.TempTokenDTO createTempToken(String email) {
         Date now = new Date();
@@ -79,28 +141,28 @@ public class JwtTokenProvider {
 
     /**
      * JWT 토큰 생성 -> 위 createToken 메서드에서 호출
-     * @param memberId 회원 ID
-     * @param now 현재 시간
+     *
+     * @param memberId       회원 ID
+     * @param now            현재 시간
      * @param expirationTime 만료 시간
-     * @param tokenType 토큰 타입
+     * @param tokenType      토큰 타입
      * @return 생성된 토큰
      */
     private String generateToken(Long memberId, Date now, long expirationTime, String tokenType) {
         return Jwts.builder()
-            .claim("memberId", memberId) // 회원 ID
-            .claim("tokenType", tokenType) // 토큰 타입
-            .setIssuedAt(now) // 발급 시간
-            .setExpiration(new Date(now.getTime() + expirationTime)) // 만료 시간
-            .signWith(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
-            .compact();
+                .claim("memberId", memberId) // 회원 ID
+                .claim("tokenType", tokenType) // 토큰 타입
+                .setIssuedAt(now) // 발급 시간
+                .setExpiration(new Date(now.getTime() + expirationTime)) // 만료 시간
+                .signWith(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
     }
-
-    // JWT 임시 토큰 생성 -> 위 createTempToken 메서드에서 호출
 
     /**
      * JWT 임시 토큰 생성
+     *
      * @param email 이메일
-     * @param now  현재 시간
+     * @param now   현재 시간
      * @return 생성된 임시 토큰
      */
     private String generateTempToken(String email, Date now) {
@@ -113,24 +175,17 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // 토큰 유효성 검사 -> 유효기간 만료 여부 확인
-    public boolean isTokenExpired(String token) {
-        return validateToken(token, true) == ErrorStatus._EXPIRED_JWT;
-    }
 
-    // 토큰 유효성 검사 -> 외부 호출 용
-    public boolean validateToken(String token) {
-        return validateToken(token, false) == null;
-    }
-
-    // 토큰 유효성 검사
     private ErrorStatus validateToken(String token, boolean checkExpirationOnly) {
         try {
-            Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes())).build().parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes())).build()
+                    .parseClaimsJws(token);
             return null;
         } catch (ExpiredJwtException e) {
             // 만료된 토큰
-            if (checkExpirationOnly) return ErrorStatus._EXPIRED_JWT;
+            if (checkExpirationOnly) {
+                return ErrorStatus._EXPIRED_JWT;
+            }
             throw new GeneralException(ErrorStatus._EXPIRED_JWT);
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             // 잘못된 JWT 서명
@@ -152,38 +207,11 @@ public class JwtTokenProvider {
     }
 
     /**
-     * 토큰을 이용하여 사용자 인증을 수행합니다.
-     * @param token 토큰
-     * @param userDetails 사용자 정보
-     * @return 사용자 인증 정보
-     */
-    public Authentication getAuthentication(String token, UserDetails userDetails) {
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-    }
-
-    /**
-     * 토큰을 해석하여 회원 ID를 반환합니다.
-     * @param request HTTP 요청
-     * @return 회원 ID
-     */
-    public String resolveToken(HttpServletRequest request) {
-        return resolveHeaderToken(request, "Authorization", "Bearer ");
-    }
-
-    /**
-     * 리프레시 토큰을 해석하여 반환합니다.
-     * @param request HTTP 요청
-     * @return 리프레시 토큰
-     */
-    public String resolveRefreshToken(HttpServletRequest request) {
-        return resolveHeaderToken(request, "refreshToken", "");
-    }
-
-    /**
      * 헤더에서 토큰을 추출합니다.
-     * @param request HTTP 요청
+     *
+     * @param request    HTTP 요청
      * @param headerName 헤더 이름
-     * @param prefix 토큰 접두사
+     * @param prefix     토큰 접두사
      * @return 추출된 토큰
      */
     private String resolveHeaderToken(HttpServletRequest request, String headerName, String prefix) {
@@ -195,27 +223,8 @@ public class JwtTokenProvider {
     }
 
     /**
-     * 리프레시 토큰을 이용하여 토큰을 재발급합니다.
-     * @param refreshToken 리프레시 토큰
-     * @return 새로 발급된 토큰
-     */
-    public TokenDTO reissueToken(String refreshToken) {
-        Long memberId = getMemberIdByToken(refreshToken);
-        return createToken(memberId);
-    }
-
-    /**
-     * 토큰을 이용하여 회원 ID를 반환합니다.
-     * @param token 토큰
-     * @return 회원 ID
-     */
-    public Long getMemberIdByToken(String token) {
-        Claims claims = getClaims(token);
-        return claims.get("memberId", Long.class);
-    }
-
-    /**
      * 임시 토큰을 이용하여 이메일을 반환합니다.
+     *
      * @param tempToken 임시 토큰
      * @return 이메일
      */
@@ -226,6 +235,7 @@ public class JwtTokenProvider {
 
     /**
      * 토큰을 해석하여 클레임을 반환합니다.
+     *
      * @param token 토큰
      * @return 클레임
      */


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #32 

<br/>

## 🔎 작업 내용

- `OAuthStrategy` 수정 : 도메인 생성의 책임을 이동시켜 도메인 - 전략 간 결합 감소
- 전략 팩토리 관련 수정 :`EnumMap` 사용
- `OAuthMemberProcessor` 책임 분리
   

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer error responses for expired or invalid tokens during authentication.
- Refactor
  - Streamlined social login to use a unified profile-based flow across providers for more reliable sign-in.
  - Improved handling of account conflicts and inactive accounts during OAuth login.
  - Standardized token creation, validation, and reissue for consistent behavior.
  - Simplified refresh token management to enhance session stability.
- Bug Fixes
  - Reduced login failures caused by provider mismatches or duplicate accounts.
  - More accurate detection of profile completeness, improving onboarding flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->